### PR TITLE
fixing duplicate column name in diagnostics view in serverless SQL

### DIFF
--- a/build/synapse-sql/qpi.sql
+++ b/build/synapse-sql/qpi.sql
@@ -405,7 +405,7 @@ AS SELECT
     details.operationName,
     details.queryText,
     details.endpoint,
-    details.resourceGroup,
+    details.resourceGroup as resourceGroupInFile,
     details.resourceId,
     details.error
 FROM

--- a/build/synapse-sql/qpi.sql
+++ b/build/synapse-sql/qpi.sql
@@ -389,7 +389,7 @@ AS SELECT
     subscriptionId = r.filepath(1),
     resourceGroup = r.filepath(2),
     workspace = r.filepath(3),
-    year = CAST(r.filepath(4) AS TINYINT),
+    year = CAST(r.filepath(4) AS SMALLINT),
     month = CAST(r.filepath(5) AS TINYINT),
     day = CAST(r.filepath(6) AS TINYINT),
     hour = CAST(r.filepath(7) AS TINYINT),


### PR DESCRIPTION
fixing error:
Column names in each view or function must be unique. Column name 'resourceGroup' in view or function 'diagnostics' is specified more than once.

also fixing year data type as 2022 doesn't fit in TINYINT